### PR TITLE
Comments now use Datastore for permanent storage

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -58,17 +58,17 @@ function displayComments(){
   
   fetch('/data').then(response => response.json()).then((commentHistory) => {
     const commentSection = document.getElementById("existing-comments");
-    if((typeof commentHistory === 'string')&&(commentHistory.localeCompare("No comments found.")==0)) {
+    if((typeof commentHistory === 'string') && (commentHistory.localeCompare("No comments found.")==0)) {
       commentSection.innerHTML = " <p> No comments yet. Leave yours!</p>";
       return;
     }
     for(i = 0; i<commentHistory.length;i++){
-      createCommentElement(commentHistory[i].username,commentHistory[i].content);
+      createCommentElement(commentHistory[i].username, commentHistory[i].content);
     }
   });
 }
 
-function createCommentElement(user, comment ){
+function createCommentElement(user, comment){
   const commentElement = document.createElement('div');
 
   const username = document.createElement('h3');
@@ -82,5 +82,6 @@ function createCommentElement(user, comment ){
   commentElement.appendChild(username);
   commentElement.appendChild(content);
   commentElement.appendChild(divider);
+
   document.getElementById("existing-comments").appendChild(commentElement);
 }


### PR DESCRIPTION
- added datastore dependency to pom.xml 

- DataServlet: doPost() now adds a comment entity to the data storage, with a username, comment, and timestamp. doGet() then retrieves the stored comments and returns them as a JSON arraylist. 